### PR TITLE
Experimental/new wp table/1 saving

### DIFF
--- a/frontend/app/components/api/api-v3/hal/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal/hal-resource.service.ts
@@ -95,7 +95,7 @@ function halResource(halTransform, HalLink, $q) {
       element._links = {};
 
       linked.forEach(linkName => {
-        if (typeof(this[linkName]) === 'object' && this[linkName].$links && !angular.isFunction(this[linkName])) {
+        if (this[linkName] && !angular.isFunction(this[linkName])) {
           element._links[linkName] = element[linkName].$links.self.$link;
         }
 

--- a/frontend/app/components/api/api-v3/hal/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal/hal-resource.service.ts
@@ -95,7 +95,7 @@ function halResource(halTransform, HalLink, $q) {
       element._links = {};
 
       linked.forEach(linkName => {
-        if (this[linkName] && !angular.isFunction(this[linkName])) {
+        if (typeof(this[linkName]) === 'object' && this[linkName].$links && !angular.isFunction(this[linkName])) {
           element._links[linkName] = element[linkName].$links.self.$link;
         }
 

--- a/frontend/app/components/api/api-v3/hal/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal/work-package-resource.service.ts
@@ -26,13 +26,16 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-function wpResource(HalResource: typeof op.HalResource) {
+function wpResource(HalResource: typeof op.HalResource, NotificationsService:any) {
   class WorkPackageResource extends HalResource {
     private form;
 
     getForm() {
       if (!this.form) {
         this.form = this.$links.update(this);
+        this.form.catch(error => {
+          NotificationsService.addError(error.data.message);
+        });
       }
       return this.form;
     }
@@ -63,17 +66,17 @@ function wpResource(HalResource: typeof op.HalResource) {
       delete plain.updatedAt;
 
       return this.getForm().then(form => {
-        var plain_payload = form.embedded.payload.data();
-        var schema = form.embedded.schema;
+        var plain_payload = form.payload.$source;
+        var schema = form.$embedded.schema;
 
-        for (property in data) {
-          if (data[property] && schema[property] && schema[property]['writable'] === true) {
-            plain_payload[property] = data[property];
+        for (property in plain) {
+          if (plain[property] && schema.hasOwnProperty(property) && schema[property] && schema[property]['writable'] === true) {
+            plain_payload[property] = plain[property];
           }
         }
-        for (property in data._links) {
-          if (data._links[property] && schema[property] && schema[property]['writable'] === true) {
-            plain_payload._links[property] = data._links[property];
+        for (property in plain._links) {
+          if (plain._links[property] && schema.hasOwnProperty(property) && schema[property] && schema[property]['writable'] === true) {
+            plain_payload._links[property] = plain._links[property];
           }
         }
 

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -50,8 +50,7 @@ export class WorkPackageEditFieldController {
   }
 
   public submit() {
-    this.deactivate();
-    this.formCtrl.updateWorkPackage();
+    this.formCtrl.updateWorkPackage().then(this.deactivate);
   }
 
   public activate() {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -50,7 +50,9 @@ export class WorkPackageEditFieldController {
   }
 
   public submit() {
-    this.formCtrl.updateWorkPackage().then(this.deactivate);
+    this.formCtrl.updateWorkPackage().then(() => {
+      this.deactivate();
+    });
   }
 
   public activate() {

--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -29,7 +29,7 @@
 export class WorkPackageEditFormController {
   public workPackage;
 
-  constructor(protected NotificationsService) {
+  constructor(protected NotificationsService, protected $q) {
   }
 
   public loadSchema() {
@@ -37,9 +37,21 @@ export class WorkPackageEditFormController {
   }
 
   public updateWorkPackage() {
-    this.workPackage.save().catch(error => {
-      this.NotificationsService.addError('There was an error ...');
+    var deferred = this.$q.defer();
+
+    this.workPackage.save()
+    .then(deferred.resolve)
+    .catch(error => {
+      if (error && error.data && error.data.message) {
+        this.NotificationsService.addError(error.data.message);
+      } else {
+        this.NotificationsService.addError("An internal error has occcurred.");
+      }
+
+      return deferred.reject();
     });
+
+    return deferred.promise;
   }
 }
 

--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -40,7 +40,9 @@ export class WorkPackageEditFormController {
     var deferred = this.$q.defer();
 
     this.workPackage.save()
-    .then(deferred.resolve)
+    .then(() => {
+      deferred.resolve();
+    })
     .catch(error => {
       if (error && error.data && error.data.message) {
         this.NotificationsService.addError(error.data.message);


### PR DESCRIPTION
Automatically remove non writable properties from the work package, when using `save` controller

- [x] get the form for the work package in order to extract the payload object from it. This will enable us to also handle cases where fields have been added in the meantime (e.g. custom fields) or where fields have been added by switching the type (e.g. custom fields). We will also need part of it for handling the creation of a work package. 
- [ ] add all the attributes that have changed in the work package to the payload object. I would like to introduce a method similar to [changes in Active Record](http://api.rubyonrails.org/classes/ActiveModel/Dirty.html#method-i-changes). But take only those that the schema proclaims to be `writable`. The `lockVersion` attribute is not writable but the payload will already have a lockVersion attribute set correctly.
- [x] patch the work package by sending the payload 
- [x] handle errors on saving (e.g. lockVersion mismatch)
- [x] Update lockVersion and probably even the whole form after a call to work_package#patch. Otherwise it is not possible to do more than one edit. 