### PR TITLE
introduce collectionResource

### DIFF
--- a/frontend/app/components/api/api-v3/hal-transform/hal-transform.config.ts
+++ b/frontend/app/components/api/api-v3/hal-transform/hal-transform.config.ts
@@ -26,10 +26,11 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-function halTransformConfig(halTransformTypes, HalResource, WorkPackageResource) {
+function halTransformConfig(halTransformTypes, HalResource, WorkPackageResource, CollectionResource) {
   angular.extend(halTransformTypes, {
     'default': HalResource,
-    WorkPackage: WorkPackageResource
+    WorkPackage: WorkPackageResource,
+    Collection: CollectionResource
   });
 }
 

--- a/frontend/app/components/api/api-v3/hal/collection-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal/collection-resource.service.test.ts
@@ -26,20 +26,26 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-function apiV3Config(apiV3, halTransform) {
-  apiV3.addResponseInterceptor((data, operation, what) => {
-    apiV3.addElementTransformer(what, halTransform);
+describe('CollectionResource', () => {
+  var CollectionResource;
 
-    if (data && operation === 'getList' && data._type === 'Collection') {
-      var resp = [];
-      angular.extend(resp, data);
-      return resp;
-    }
+  beforeEach(angular.mock.module('openproject.api'));
 
-    return data;
+  beforeEach(angular.mock.inject((_CollectionResource_) => {
+    CollectionResource = _CollectionResource_;
+  }));
+
+  describe('getElements', () => {
+    it('returns the embedded elements', () => {
+      var plain = {
+                    $embedded: {
+                      elements: [1,2,3]
+                    }
+                  }
+
+      var resource = new CollectionResource(plain);
+
+      expect(resource.getElements()).to.eql(plain.$embedded.elements);
+    });
   });
-}
-
-angular
-  .module('openproject.api')
-  .run(apiV3Config);
+});

--- a/frontend/app/components/api/api-v3/hal/collection-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal/collection-resource.service.ts
@@ -1,4 +1,4 @@
-// -- copyright
+//-- copyright
 // OpenProject is a project management system.
 // Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 //
@@ -24,22 +24,20 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // See doc/COPYRIGHT.rdoc for more details.
-// ++
+//++
 
-function apiV3Config(apiV3, halTransform) {
-  apiV3.addResponseInterceptor((data, operation, what) => {
-    apiV3.addElementTransformer(what, halTransform);
-
-    if (data && operation === 'getList' && data._type === 'Collection') {
-      var resp = [];
-      angular.extend(resp, data);
-      return resp;
+function collectionResource(HalResource: typeof op.HalResource, apiV3) {
+  class CollectionResource extends HalResource {
+    // TODO: Check whether this is still required once embedded properties
+    // are available directly as properties on the HalResource
+    getElements() {
+      return this.$embedded.elements;
     }
+  }
 
-    return data;
-  });
+  return CollectionResource;
 }
 
 angular
   .module('openproject.api')
-  .run(apiV3Config);
+  .factory('CollectionResource', collectionResource);

--- a/frontend/app/components/api/api-v3/hal/hal-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal/hal-resource.service.test.ts
@@ -329,6 +329,50 @@ describe('halTransform service', () => {
     });
   });
 
+  describe('when transforming an object with an _embedded list with the list element having _links', () => {
+    var plainElement;
+    var transformedElement;
+
+    beforeEach(() => {
+      plainElement = {
+        _type: 'Hello',
+        _embedded: {
+          elements: [
+            { _type: 'ListElement',
+              _links: {}
+            },
+            { _type: 'ListElement',
+              _links: {}
+            }
+          ]
+        }
+      };
+
+      transformedElement = halTransform(angular.copy(plainElement));
+    });
+
+    it('should not be restangularized', () => {
+      expect(transformedElement.restangularized).to.not.be.ok;
+    });
+
+    it('should be transformed', () => {
+      expect(transformedElement.$halTransformed).to.be.true
+    });
+
+    it('should have a new "embedded" property', () => {
+      expect(transformedElement.$embedded);
+    });
+
+    it('should not have the original _embedded property', () => {
+      expect(transformedElement._embedded).to.not.be.ok;
+    });
+
+    it('should transform the list elements', () => {
+      expect(transformedElement.$embedded.elements[0].$halTransformed).to.be.true;
+      expect(transformedElement.$embedded.elements[1].$halTransformed).to.be.true;
+    });
+  });
+
   describe('when transforming an object with _links and/or _embedded', () => {
     var transformedElement;
 

--- a/frontend/app/components/api/api-v3/hal/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal/hal-resource.service.ts
@@ -119,6 +119,9 @@ function halResource(apiV3:restangular.IService, $q:ng.IQService, halTransform) 
     private transformEmbedded() {
       return this.transformHalProperty('_embedded', (embedded, element, name) => {
         angular.forEach(element, child => child && halTransform(element));
+        if (element.forEach) {
+          element.forEach((arr_element, index) => { element[index] = halTransform(arr_element) });
+        }
         embedded[name] = halTransform(element);
       });
     }

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -103,8 +103,8 @@ function WorkPackagesListController($scope,
     loadingIndicator.mainPage = fetchWorkPackages.then(function(json:api.ex.WorkPackagesMeta) {
       apiWorkPackages
         .list(json.meta.page, json.meta.per_page, json.meta.query)
-        .then((workPackages) => {
-          json.work_packages = workPackages;
+        .then((workPackageCollection) => {
+          json.work_packages = workPackageCollection.getElements();
           setupPage(json, !!queryParams);
       });
 
@@ -231,8 +231,8 @@ function WorkPackagesListController($scope,
       .then(function (json:api.ex.WorkPackagesMeta) {
         apiWorkPackages
           .list(json.meta.page, json.meta.per_page, json.meta.query, json.meta.columns)
-          .then((workPackages) => {
-            json.work_packages = workPackages;
+          .then((workPackageCollection) => {
+            json.work_packages = workPackageCollection.getElements();
             setupWorkPackagesTable(json);
         });
       });


### PR DESCRIPTION
It is then employed to then get the elements of the embedded list to populate the work packages table.

This avoids using `angular.forEach` on a halResource which will have the workPackages but additional properties besides, leading to empty rows in the wp table.